### PR TITLE
Fix missing use case exports causing JobController initialization failures

### DIFF
--- a/epistemix_api/use_cases/__init__.py
+++ b/epistemix_api/use_cases/__init__.py
@@ -11,6 +11,8 @@ from .submit_runs import submit_runs, get_runs_storage, RunRequestDict
 from .submit_run_config import submit_run_config
 from .get_job import get_job
 from .get_runs import get_runs_by_job_id
+from .get_job_uploads import get_job_uploads
+from .read_upload_content import read_upload_content
 
 __all__ = [
     'register_job', 
@@ -22,5 +24,7 @@ __all__ = [
     'get_job', 
     'get_runs_by_job_id',
     'validate_tags',
-    'RunRequestDict'
+    'RunRequestDict',
+    'get_job_uploads',
+    'read_upload_content'
 ]


### PR DESCRIPTION
## Summary
This PR fixes issue #10 by adding missing exports to the use_cases __init__.py file that were causing JobController initialization failures.

## Problem
The `JobController.create_with_repositories` method was failing with a `TypeError: the first argument must be callable` error. This was causing 18 test failures and errors in the test suite.

## Solution
Added the missing exports to `/workspaces/fred_simulations/epistemix_api/use_cases/__init__.py`:
- Import and export `get_job_uploads` from `.get_job_uploads`
- Import and export `read_upload_content` from `.read_upload_content`

## Test Results
✅ **All 203 tests now passing** (previously had 10 failures and 8 errors)

```
203 passed, 244 warnings in 8.26s
```

## Changes Made
- Modified `epistemix_api/use_cases/__init__.py` to include the missing imports and exports

## Verification
- Ran full test suite: `poetry run pytest epistemix_api/ -n auto`
- All tests pass successfully
- Pre-commit hooks have been configured to prevent future test failures

Fixes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public API to include new capabilities for accessing job uploads and reading upload content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->