### PR TITLE
fix(FRED-12): Fix Sceptre configuration issues

### DIFF
--- a/epistemix_platform/infrastructure/config/config.yaml
+++ b/epistemix_platform/infrastructure/config/config.yaml
@@ -5,8 +5,7 @@ region: us-east-1
 # template_bucket_name: fred-simulations-sceptre-templates
 
 # Default tags applied to all stacks
-template_defaults:
-  tags:
-    Project: FREDSimulations
-    ManagedBy: Sceptre
-    CreatedWith: InfrastructureAsCode
+stack_tags:
+  Project: FREDSimulations
+  ManagedBy: Sceptre
+  CreatedWith: InfrastructureAsCode

--- a/epistemix_platform/infrastructure/config/dev/config.yaml
+++ b/epistemix_platform/infrastructure/config/dev/config.yaml
@@ -2,10 +2,9 @@ project_code: fred-simulations
 region: us-east-1
 
 # Development environment configuration
-template_defaults:
-  tags:
-    Environment: dev
-    Project: FREDSimulations
-    ManagedBy: Sceptre
-    CreatedWith: InfrastructureAsCode
-    CostCenter: Development
+stack_tags:
+  Environment: dev
+  Project: FREDSimulations
+  ManagedBy: Sceptre
+  CreatedWith: InfrastructureAsCode
+  CostCenter: Development

--- a/epistemix_platform/infrastructure/config/production/config.yaml
+++ b/epistemix_platform/infrastructure/config/production/config.yaml
@@ -2,11 +2,10 @@ project_code: fred-simulations
 region: us-east-1
 
 # Production environment configuration
-template_defaults:
-  tags:
-    Environment: production
-    Project: FREDSimulations
-    ManagedBy: Sceptre
-    CreatedWith: InfrastructureAsCode
-    CostCenter: Production
-    Backup: true
+stack_tags:
+  Environment: production
+  Project: FREDSimulations
+  ManagedBy: Sceptre
+  CreatedWith: InfrastructureAsCode
+  CostCenter: Production
+  Backup: true

--- a/epistemix_platform/infrastructure/config/staging/config.yaml
+++ b/epistemix_platform/infrastructure/config/staging/config.yaml
@@ -2,10 +2,9 @@ project_code: fred-simulations
 region: us-east-1
 
 # Staging environment configuration
-template_defaults:
-  tags:
-    Environment: staging
-    Project: FREDSimulations
-    ManagedBy: Sceptre
-    CreatedWith: InfrastructureAsCode
-    CostCenter: Staging
+stack_tags:
+  Environment: staging
+  Project: FREDSimulations
+  ManagedBy: Sceptre
+  CreatedWith: InfrastructureAsCode
+  CostCenter: Staging


### PR DESCRIPTION
## Summary
- Fixed incorrect Sceptre configuration key usage
- Added missing trailing newlines to YAML files
- Ensures CloudFormation tags are properly applied to stacks

## Changes Made

### Configuration Key Fix
- Replaced `template_defaults` with `stack_tags` in all config files:
  - `config/config.yaml` (global)
  - `config/dev/config.yaml`
  - `config/staging/config.yaml`
  - `config/production/config.yaml`

### File Format Fix
- Added trailing newlines to all config.yaml files (YAML best practice)

## Why This Change Is Needed

The `template_defaults` configuration key is not recognized by Sceptre. Using `stack_tags` ensures that CloudFormation tags are properly applied to all stacks. This fixes tag application issues and follows Sceptre's documented configuration structure.

## Testing
- Configuration syntax validated
- Trailing newlines verified on all files
- Tag structure consistency maintained across environments

## Linear Issue
[FRED-12: Fix Sceptre Configuration Issues](https://linear.app/tackle-chop-urgent/issue/FRED-12/fix-sceptre-configuration-issues)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized how default stack tags are defined by moving them to a top-level key across dev, staging, and production, simplifying configuration management.
- Chores
  - Consolidated tag definitions without changing values (e.g., Environment, Project, ManagedBy, CreatedWith, CostCenter, Backup where applicable).
  - No functional impact expected; behavior remains the same across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->