### PR TITLE
fix(FRED-15): Fix test naming and documentation consistency

### DIFF
--- a/epistemix_platform/infrastructure/tests/s3/test_s3_upload_bucket_template.py
+++ b/epistemix_platform/infrastructure/tests/s3/test_s3_upload_bucket_template.py
@@ -277,8 +277,8 @@ class TestS3Template:
         assert "ExpirationInDays" in complete_rule
         assert complete_rule["ExpirationInDays"] == 7
 
-    def test_s3__lifecycle_policies__complete_file_lifecycle_non_current_version__has_1_transition_rules(self, s3_template: Dict[str, Any]):
-        """Test that complete file lifecycle non-current version has exactly 2 transition rules."""
+    def test_s3__lifecycle_policies__complete_file_lifecycle_non_current_version__has_1_transition_rule(self, s3_template: Dict[str, Any]):
+        """Test that complete file lifecycle non-current version has exactly 1 transition rule."""
         bucket = s3_template["Resources"]["UploadBucket"]
         lifecycle_rules = bucket["Properties"]["LifecycleConfiguration"]["Rules"]
 
@@ -289,8 +289,8 @@ class TestS3Template:
         non_current_transitions = complete_rule["NoncurrentVersionTransitions"]
         assert len(non_current_transitions) == 1
 
-    def test_s3__lifecycle_policies__complete_file_lifecycle_moves_non_current_versions_to_glacier_after_2_day(self, s3_template: Dict[str, Any]):
-        """Test that complete file lifecycle moves non-current versions to Glacier after 1 day."""
+    def test_s3__lifecycle_policies__complete_file_lifecycle_moves_non_current_versions_to_glacier_after_2_days(self, s3_template: Dict[str, Any]):
+        """Test that complete file lifecycle moves non-current versions to Glacier after 2 days."""
         bucket = s3_template["Resources"]["UploadBucket"]
         lifecycle_rules = bucket["Properties"]["LifecycleConfiguration"]["Rules"]
 


### PR DESCRIPTION
## Summary
- Fixed test method naming for grammatical consistency
- Aligned test docstrings with actual test assertions
- Improved test clarity and maintainability

## Issues Fixed

### Test Naming Issues:
1. **Pluralization fix**: `has_1_transition_rules` → `has_1_transition_rule` (singular)
2. **Grammar fix**: `after_2_day` → `after_2_days` (plural)

### Documentation Mismatches:
1. **Docstring correction**: "has exactly 2 transition rules" → "has exactly 1 transition rule"
   - The assertion checks `len(non_current_transitions) == 1`
2. **Docstring correction**: "after 1 day" → "after 2 days"  
   - The assertion checks `TransitionInDays == 2`

## File Changed
- `epistemix_platform/infrastructure/tests/s3/test_s3_upload_bucket_template.py`

## Impact
These changes ensure test names and documentation accurately reflect what the tests are actually asserting. This improves:
- Code readability
- Test maintainability
- Developer understanding of test intent

## Linear Issue
[FRED-15: Fix test naming and documentation](https://linear.app/tackle-chop-urgent/issue/FRED-15/fix-test-naming-and-documentation)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Tests
  - Renamed two S3 lifecycle policy tests to improve clarity and grammar (e.g., “rule” and “2 days”), enhancing readability in test reports and CI logs. No functional changes.
- Documentation
  - Updated test descriptions to align with the clarified test names for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->